### PR TITLE
Stop early if randomize_stat_freqs won't do anything

### DIFF
--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -523,7 +523,6 @@ pub fn lz77_optimal<C: Cache>(
                     let dists_changed = randomize_freqs(&mut stats.dists, &mut ran_state);
                     changed |= dists_changed;
                 }
-                stats.litlens[256] = 1; // End symbol.
                 stats.calculate_entropy();
                 lastrandomstep = i;
             } else {

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -109,21 +109,29 @@ impl Default for SymbolStats {
 
 impl SymbolStats {
     fn randomize_stat_freqs(&mut self, state: &mut RanState) {
-        fn randomize_freqs(freqs: &mut [usize], state: &mut RanState) {
+        /// Returns true if it actually made a change.
+        fn randomize_freqs(freqs: &mut [usize], state: &mut RanState) -> bool {
             let n = freqs.len();
             let mut i = 0;
             let end = n;
-
+            let mut changed = false;
             while i < end {
                 if (state.random_marsaglia() >> 4) % 3 == 0 {
                     let index = state.random_marsaglia() as usize % n;
-                    freqs[i] = freqs[index];
+                    if freqs[i] != freqs[index] {
+                        freqs[i] = freqs[index];
+                        changed = true;
+                    }
                 }
                 i += 1;
             }
+            changed
         }
-        randomize_freqs(&mut self.litlens, state);
-        randomize_freqs(&mut self.dists, state);
+        let mut changed = false;
+        while !changed {
+            changed = randomize_freqs(&mut self.litlens, state);
+            changed |= randomize_freqs(&mut self.dists, state);
+        }
         self.litlens[256] = 1; // End symbol.
     }
 

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -504,7 +504,7 @@ pub fn lz77_optimal<C: Cache>(
                     let end = n;
                     let mut changed = false;
                     while i < end {
-                        if i != 256 && (state.random_marsaglia() >> 4) % 3 == 0 {
+                        if (state.random_marsaglia() >> 4) % 3 == 0 && i != 256 {
                             let index = state.random_marsaglia() as usize % n;
                             if i != index && freqs[i] != freqs[index] {
                                 freqs[i] = freqs[index];

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -504,9 +504,9 @@ pub fn lz77_optimal<C: Cache>(
                     let end = n;
                     let mut changed = false;
                     while i < end {
-                        if (state.random_marsaglia() >> 4) % 3 == 0 {
+                        if i != 256 && (state.random_marsaglia() >> 4) % 3 == 0 {
                             let index = state.random_marsaglia() as usize % n;
-                            if freqs[i] != freqs[index] {
+                            if i != index && freqs[i] != freqs[index] {
                                 freqs[i] = freqs[index];
                                 changed = true;
                             }
@@ -523,7 +523,7 @@ pub fn lz77_optimal<C: Cache>(
                     let dists_changed = randomize_freqs(&mut stats.dists, &mut ran_state);
                     changed |= dists_changed;
                 }
-                stats.litlens[256] = 1;
+                stats.litlens[256] = 1; // End symbol.
                 stats.calculate_entropy();
                 lastrandomstep = i;
             } else {

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -511,10 +511,24 @@ pub fn lz77_optimal<C: Cache>(
             stats.calculate_entropy();
         }
         if i > 5 && (cost - lastcost).abs() < f64::EPSILON {
-            stats = beststats;
-            stats.randomize_stat_freqs(&mut ran_state);
-            stats.calculate_entropy();
-            lastrandomstep = i;
+            if beststats
+                .litlens
+                .iter()
+                .copied()
+                .any(|litlen| litlen != beststats.litlens[0])
+                || beststats
+                    .dists
+                    .iter()
+                    .copied()
+                    .any(|dist| dist != beststats.dists[0])
+            {
+                stats = beststats;
+                stats.randomize_stat_freqs(&mut ran_state);
+                stats.calculate_entropy();
+                lastrandomstep = i;
+            } else {
+                break;
+            }
         }
         lastcost = cost;
     }

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -130,7 +130,10 @@ impl SymbolStats {
         let mut changed = false;
         while !changed {
             changed = randomize_freqs(&mut self.litlens, state);
-            changed |= randomize_freqs(&mut self.dists, state);
+
+            // Pull into a separate variable to prevent short-circuiting
+            let dists_changed = randomize_freqs(&mut self.dists, state);
+            changed |= dists_changed;
         }
         self.litlens[256] = 1; // End symbol.
     }

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -511,13 +511,6 @@ pub fn lz77_optimal<C: Cache>(
         let laststats = stats;
         stats.clear_freqs();
         stats.get_statistics(&currentstore);
-        if lastrandomstep != -1 {
-            /* This makes it converge slower but better. Do it only once the
-            randomness kicks in so that if the user does few iterations, it gives a
-            better result sooner. */
-            stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
-            stats.calculate_entropy();
-        }
         if i > 5 && (cost - lastcost).abs() < f64::EPSILON {
             if beststats
                 .litlens
@@ -537,6 +530,12 @@ pub fn lz77_optimal<C: Cache>(
             } else {
                 break;
             }
+        } else if lastrandomstep != -1 {
+            /* This makes it converge slower but better. Do it only once the
+            randomness kicks in so that if the user does few iterations, it gives a
+            better result sooner. */
+            stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
+            stats.calculate_entropy();
         }
         lastcost = cost;
     }

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,8 +15,19 @@ done
 mkdir -p test/temp_compressed/
 mv test/data/*.gz test/temp_compressed/
 
-# Compare newly compressed data with expected
-diff -r test/results/ test/temp_compressed/
+# Compare newly compressed data size with expected
+cd test/results
+find . -type f | while read -r file; do
+  reference_size=$(stat -c%s "../../test/temp_compressed/$file")
+  current_result_size=$(stat -c%s "$file")
+  if [[ $current_result_size > $reference_size ]]; then
+    echo "File $file is larger than expected ($current_result_size vs $reference_size bytes)"
+    exit 1
+  elif [[ $current_result_size < $reference_size ]]; then
+    echo "Compression ratio improved for $file! ($current_result_size vs $reference_size bytes)"
+  fi
+done
+cd ../..
 
 # Verify that all compressed files decompress back to the input sources
 mkdir -p test/temp_decompressed/


### PR DESCRIPTION
`randomize_stat_freqs` can't have any effect in the case where all the symbols in `beststats` have the same frequency, nor does `lz77_optimal` have any way to improve the compression if that's the case and the last iteration had no effect (and I doubt any improvement is *possible* since this means they follow a maximum-entropy distribution). So this PR ends the deflation of the block early if that happens.

As well, since the above check means it can no longer get stuck in an infinite loop, this PR changes randomize_stat_freqs to run again if it hasn't made an actual change, which eliminates redundant LZ77 runs. Dead-code elimination could not have done this, because calling a PRNG mutates its state.

This PR also postpones running `add_weighed_stat_freqs` until we know its result won't be overwritten from `best_stats` before it's used.