### PR TITLE
Convenience rollup of PR 21 + PR 22

### DIFF
--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use core::{cmp, iter};
+use core::{cmp, iter, num::NonZeroU64};
 
 use log::{debug, log_enabled};
 
@@ -1186,7 +1186,14 @@ fn blocksplit_attempt<W: Write>(
     for &item in &splitpoints_uncompressed {
         let mut s = ZopfliBlockState::new(options, last, item);
 
-        let store = lz77_optimal(&mut s, in_data, last, item, options.iteration_count.get());
+        let store = lz77_optimal(
+            &mut s,
+            in_data,
+            last,
+            item,
+            options.iteration_count.map(NonZeroU64::get),
+            options.iterations_without_improvement.map(NonZeroU64::get),
+        );
         totalcost += calculate_block_size_auto_type(&store, 0, store.size());
 
         // ZopfliAppendLZ77Store(&store, &lz77);
@@ -1202,7 +1209,14 @@ fn blocksplit_attempt<W: Write>(
 
     let mut s = ZopfliBlockState::new(options, last, inend);
 
-    let store = lz77_optimal(&mut s, in_data, last, inend, options.iteration_count.get());
+    let store = lz77_optimal(
+        &mut s,
+        in_data,
+        last,
+        inend,
+        options.iteration_count.map(NonZeroU64::get),
+        options.iterations_without_improvement.map(NonZeroU64::get),
+    );
     totalcost += calculate_block_size_auto_type(&store, 0, store.size());
 
     // ZopfliAppendLZ77Store(&store, &lz77);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod util;
 #[cfg(feature = "zlib")]
 mod zlib;
 
-use core::num::NonZeroU8;
+use core::num::NonZeroU64;
 #[cfg(all(not(doc), feature = "std"))]
 use std::io::{Error, Write};
 
@@ -80,10 +80,13 @@ pub struct Options {
     #[cfg_attr(
         all(test, feature = "std"),
         proptest(
-            strategy = "(1..=10u8).prop_map(|iteration_count| NonZeroU8::new(iteration_count).unwrap())"
+            strategy = "(1..=10u64).prop_map(|iteration_count| NonZeroU64::new(iteration_count))"
         )
     )]
-    pub iteration_count: NonZeroU8,
+    pub iteration_count: Option<NonZeroU64>,
+    /// Stop after rerunning forward and backward pass this many times without finding
+    /// a smaller representation of the block.
+    pub iterations_without_improvement: Option<NonZeroU64>,
     /// Maximum amount of blocks to split into (0 for unlimited, but this can give
     /// extreme results that hurt compression on some files).
     ///
@@ -94,7 +97,8 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Options {
         Options {
-            iteration_count: NonZeroU8::new(15).unwrap(),
+            iteration_count: Some(NonZeroU64::new(15).unwrap()),
+            iterations_without_improvement: None,
             maximum_block_splits: 15,
         }
     }

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -528,9 +528,9 @@ pub fn lz77_optimal<C: Cache>(
                     let end = n;
                     let mut changed = false;
                     while i < end {
-                        if (state.random_marsaglia() >> 4) % 3 == 0 {
+                        if i != 256 && (state.random_marsaglia() >> 4) % 3 == 0 {
                             let index = state.random_marsaglia() as usize % n;
-                            if freqs[i] != freqs[index] {
+                            if i != index && freqs[i] != freqs[index] {
                                 freqs[i] = freqs[index];
                                 changed = true;
                             }
@@ -547,7 +547,7 @@ pub fn lz77_optimal<C: Cache>(
                     let dists_changed = randomize_freqs(&mut stats.dists, &mut ran_state);
                     changed |= dists_changed;
                 }
-                stats.litlens[256] = 1;
+                stats.litlens[256] = 1; // End symbol.
                 stats.calculate_entropy();
                 lastrandomstep = current_iteration;
             } else {

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -450,7 +450,8 @@ pub fn lz77_optimal<C: Cache>(
     in_data: &[u8],
     instart: usize,
     inend: usize,
-    numiterations: u8,
+    max_iterations: Option<u64>,
+    max_iterations_without_improvement: Option<u64>,
 ) -> Lz77Store {
     /* Dist to get to here with smallest cost. */
     let mut currentstore = Lz77Store::new();
@@ -470,13 +471,15 @@ pub fn lz77_optimal<C: Cache>(
     let mut lastcost = 0.0;
     /* Try randomizing the costs a bit once the size stabilizes. */
     let mut ran_state = RanState::new();
-    let mut lastrandomstep = -1;
+    let mut lastrandomstep = u64::MAX;
 
     /* Do regular deflate, then loop multiple shortest path runs, each time using
     the statistics of the previous run. */
     /* Repeat statistics with each time the cost model from the previous stat
     run. */
-    for i in 0..numiterations as i32 {
+    let mut current_iteration: u64 = 0;
+    let mut iterations_without_improvement: u64 = 0;
+    loop {
         currentstore.reset();
         lz77_optimal_run(
             s,
@@ -491,30 +494,43 @@ pub fn lz77_optimal<C: Cache>(
         let cost = calculate_block_size(&currentstore, 0, currentstore.size(), BlockType::Dynamic);
 
         if cost < bestcost {
+            iterations_without_improvement = 0;
             /* Copy to the output store. */
             outputstore = currentstore.clone();
             beststats = stats;
             bestcost = cost;
 
-            debug!("Iteration {}: {} bit", i, cost);
+            debug!("Iteration {}: {} bit", current_iteration, cost);
         } else {
-            trace!("Iteration {}: {} bit", i, cost);
+            iterations_without_improvement += 1;
+            trace!("Iteration {}: {} bit", current_iteration, cost);
+            if let Some(max_iterations_without_improvement) = max_iterations_without_improvement {
+                if iterations_without_improvement >= max_iterations_without_improvement {
+                    break;
+                }
+            }
+        }
+        current_iteration += 1;
+        if let Some(max_iterations) = max_iterations {
+            if current_iteration >= max_iterations {
+                break;
+            }
         }
         let laststats = stats;
         stats.clear_freqs();
         stats.get_statistics(&currentstore);
-        if lastrandomstep != -1 {
+        if lastrandomstep != u64::MAX {
             /* This makes it converge slower but better. Do it only once the
             randomness kicks in so that if the user does few iterations, it gives a
             better result sooner. */
             stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
             stats.calculate_entropy();
         }
-        if i > 5 && (cost - lastcost).abs() < f64::EPSILON {
+        if current_iteration > 5 && (cost - lastcost).abs() < f64::EPSILON {
             stats = beststats;
             stats.randomize_stat_freqs(&mut ran_state);
             stats.calculate_entropy();
-            lastrandomstep = i;
+            lastrandomstep = current_iteration;
         }
         lastcost = cost;
     }

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -523,7 +523,6 @@ pub fn lz77_optimal<C: Cache>(
                     let dists_changed = randomize_freqs(&mut stats.dists, &mut ran_state);
                     changed |= dists_changed;
                 }
-                stats.litlens[256] = 1; // End symbol.
                 stats.calculate_entropy();
                 lastrandomstep = i;
             } else {

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -527,13 +527,6 @@ pub fn lz77_optimal<C: Cache>(
         let laststats = stats;
         stats.clear_freqs();
         stats.get_statistics(&currentstore);
-        if lastrandomstep != u64::MAX {
-            /* This makes it converge slower but better. Do it only once the
-            randomness kicks in so that if the user does few iterations, it gives a
-            better result sooner. */
-            stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
-            stats.calculate_entropy();
-        }
         if current_iteration > 5 && (cost - lastcost).abs() < f64::EPSILON {
             if beststats
                 .litlens
@@ -553,6 +546,12 @@ pub fn lz77_optimal<C: Cache>(
             } else {
                 break;
             }
+        } else if lastrandomstep != u64::MAX {
+            /* This makes it converge slower but better. Do it only once the
+            randomness kicks in so that if the user does few iterations, it gives a
+            better result sooner. */
+            stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
+            stats.calculate_entropy();
         }
         lastcost = cost;
     }

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -109,21 +109,29 @@ impl Default for SymbolStats {
 
 impl SymbolStats {
     fn randomize_stat_freqs(&mut self, state: &mut RanState) {
-        fn randomize_freqs(freqs: &mut [usize], state: &mut RanState) {
+        /// Returns true if it actually made a change.
+        fn randomize_freqs(freqs: &mut [usize], state: &mut RanState) -> bool {
             let n = freqs.len();
             let mut i = 0;
             let end = n;
-
+            let mut changed = false;
             while i < end {
                 if (state.random_marsaglia() >> 4) % 3 == 0 {
                     let index = state.random_marsaglia() as usize % n;
-                    freqs[i] = freqs[index];
+                    if freqs[i] != freqs[index] {
+                        freqs[i] = freqs[index];
+                        changed = true;
+                    }
                 }
                 i += 1;
             }
+            changed
         }
-        randomize_freqs(&mut self.litlens, state);
-        randomize_freqs(&mut self.dists, state);
+        let mut changed = false;
+        while !changed {
+            changed = randomize_freqs(&mut self.litlens, state);
+            changed |= randomize_freqs(&mut self.dists, state);
+        }
         self.litlens[256] = 1; // End symbol.
     }
 

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -504,9 +504,9 @@ pub fn lz77_optimal<C: Cache>(
                     let end = n;
                     let mut changed = false;
                     while i < end {
-                        if (state.random_marsaglia() >> 4) % 3 == 0 {
+                        if i != 256 && (state.random_marsaglia() >> 4) % 3 == 0 {
                             let index = state.random_marsaglia() as usize % n;
-                            if freqs[i] != freqs[index] {
+                            if i != index && freqs[i] != freqs[index] {
                                 freqs[i] = freqs[index];
                                 changed = true;
                             }
@@ -523,7 +523,7 @@ pub fn lz77_optimal<C: Cache>(
                     let dists_changed = randomize_freqs(&mut stats.dists, &mut ran_state);
                     changed |= dists_changed;
                 }
-                stats.litlens[256] = 1;
+                stats.litlens[256] = 1; // End symbol.
                 stats.calculate_entropy();
                 lastrandomstep = i;
             } else {

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -511,10 +511,24 @@ pub fn lz77_optimal<C: Cache>(
             stats.calculate_entropy();
         }
         if i > 5 && (cost - lastcost).abs() < f64::EPSILON {
-            stats = beststats;
-            stats.randomize_stat_freqs(&mut ran_state);
-            stats.calculate_entropy();
-            lastrandomstep = i;
+            if beststats
+                .litlens
+                .iter()
+                .copied()
+                .any(|litlen| litlen != beststats.litlens[0])
+                || beststats
+                    .dists
+                    .iter()
+                    .copied()
+                    .any(|dist| dist != beststats.dists[0])
+            {
+                stats = beststats;
+                stats.randomize_stat_freqs(&mut ran_state);
+                stats.calculate_entropy();
+                lastrandomstep = i;
+            } else {
+                break;
+            }
         }
         lastcost = cost;
     }

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -130,7 +130,10 @@ impl SymbolStats {
         let mut changed = false;
         while !changed {
             changed = randomize_freqs(&mut self.litlens, state);
-            changed |= randomize_freqs(&mut self.dists, state);
+
+            // Pull into a separate variable to prevent short-circuiting
+            let dists_changed = randomize_freqs(&mut self.dists, state);
+            changed |= dists_changed;
         }
         self.litlens[256] = 1; // End symbol.
     }

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -527,7 +527,7 @@ pub fn lz77_optimal<C: Cache>(
                     let end = n;
                     let mut changed = false;
                     while i < end {
-                        if i != 256 && (state.random_marsaglia() >> 4) % 3 == 0 {
+                        if (state.random_marsaglia() >> 4) % 3 == 0 && i != 256 {
                             let index = state.random_marsaglia() as usize % n;
                             if i != index && freqs[i] != freqs[index] {
                                 freqs[i] = freqs[index];

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -536,7 +536,7 @@ pub fn lz77_optimal<C: Cache>(
             stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
             stats.calculate_entropy();
         }
-        if i > 5 && (cost - lastcost).abs() < f64::EPSILON {
+        if current_iteration > 5 && (cost - lastcost).abs() < f64::EPSILON {
             if beststats
                 .litlens
                 .iter()

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -108,34 +108,6 @@ impl Default for SymbolStats {
 }
 
 impl SymbolStats {
-    fn randomize_stat_freqs(&mut self, state: &mut RanState) {
-        /// Returns true if it actually made a change.
-        fn randomize_freqs(freqs: &mut [usize], state: &mut RanState) -> bool {
-            let n = freqs.len();
-            let mut i = 0;
-            let end = n;
-            let mut changed = false;
-            while i < end {
-                if (state.random_marsaglia() >> 4) % 3 == 0 {
-                    let index = state.random_marsaglia() as usize % n;
-                    if freqs[i] != freqs[index] {
-                        freqs[i] = freqs[index];
-                        changed = true;
-                    }
-                }
-                i += 1;
-            }
-            changed
-        }
-        let mut changed = false;
-        while !changed {
-            changed = randomize_freqs(&mut self.litlens, state);
-            // Pull into a separate variable to prevent short-circuiting
-            let dists_changed = randomize_freqs(&mut self.dists, state);
-            changed |= dists_changed;
-        }
-        self.litlens[256] = 1; // End symbol.
-    }
 
     /// Calculates the entropy of each symbol, based on the counts of each symbol. The
     /// result is similar to the result of length_limited_code_lengths, but with the

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -529,7 +529,7 @@ pub fn lz77_optimal<C: Cache>(
         let laststats = stats;
         stats.clear_freqs();
         stats.get_statistics(&currentstore);
-        if lastrandomstep != -1 {
+        if lastrandomstep != u64::MAX {
             /* This makes it converge slower but better. Do it only once the
             randomness kicks in so that if the user does few iterations, it gives a
             better result sooner. */

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -547,7 +547,6 @@ pub fn lz77_optimal<C: Cache>(
                     let dists_changed = randomize_freqs(&mut stats.dists, &mut ran_state);
                     changed |= dists_changed;
                 }
-                stats.litlens[256] = 1; // End symbol.
                 stats.calculate_entropy();
                 lastrandomstep = current_iteration;
             } else {

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -511,13 +511,6 @@ pub fn lz77_optimal<C: Cache>(
         let laststats = stats;
         stats.clear_freqs();
         stats.get_statistics(&currentstore);
-        if lastrandomstep != -1 {
-            /* This makes it converge slower but better. Do it only once the
-            randomness kicks in so that if the user does few iterations, it gives a
-            better result sooner. */
-            stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
-            stats.calculate_entropy();
-        }
         if i > 5 && (cost - lastcost).abs() < f64::EPSILON {
             if beststats
                 .litlens
@@ -537,6 +530,12 @@ pub fn lz77_optimal<C: Cache>(
             } else {
                 break;
             }
+        } else if lastrandomstep != -1 {
+            /* This makes it converge slower but better. Do it only once the
+            randomness kicks in so that if the user does few iterations, it gives a
+            better result sooner. */
+            stats = add_weighed_stat_freqs(&stats, 1.0, &laststats, 0.5);
+            stats.calculate_entropy();
         }
         lastcost = cost;
     }

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,8 +15,19 @@ done
 mkdir -p test/temp_compressed/
 mv test/data/*.gz test/temp_compressed/
 
-# Compare newly compressed data with expected
-diff -r test/results/ test/temp_compressed/
+# Compare newly compressed data size with expected
+cd test/results
+find . -type f | while read -r file; do
+  reference_size=$(stat -c%s "../../test/temp_compressed/$file")
+  current_result_size=$(stat -c%s "$file")
+  if [[ $current_result_size > $reference_size ]]; then
+    echo "File $file is larger than expected ($current_result_size vs $reference_size bytes)"
+    exit 1
+  elif [[ $current_result_size < $reference_size ]]; then
+    echo "Compression ratio improved for $file! ($current_result_size vs $reference_size bytes)"
+  fi
+done
+cd ../..
 
 # Verify that all compressed files decompress back to the input sources
 mkdir -p test/temp_decompressed/


### PR DESCRIPTION
This PR contains https://github.com/zopfli-rs/zopfli/pull/21, https://github.com/zopfli-rs/zopfli/pull/22 and the changes necessary to resolve conflicts between them. It's from the branch I used for testing in https://app.circleci.com/pipelines/github/Pr0methean/OcHd-RustBuild/850/workflows/d05c2900-4e16-41a7-873a-d13108ee92a7/jobs/6475, which compressed the PNGs to a total of just 282,391 bytes in 52m7s (compare to https://app.circleci.com/pipelines/github/Pr0methean/OcHd-RustBuild/848/workflows/83c39815-4d2b-40c3-a719-233b6a259995/jobs/6462 which produced 282,243 bytes but took 53m9s).