### PR TITLE
Remove redundant parameters from some methods

### DIFF
--- a/src/blocksplitter.rs
+++ b/src/blocksplitter.rs
@@ -231,7 +231,7 @@ pub fn blocksplit(
     /* Unintuitively, Using a simple LZ77 method here instead of lz77_optimal
     results in better blocks. */
     {
-        let mut state = ZopfliBlockState::new_without_cache(options, instart, inend);
+        let mut state = ZopfliBlockState::new_without_cache(options, in_data, instart, inend);
         store.greedy(&mut state, in_data, instart, inend);
     }
 

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -1189,8 +1189,6 @@ fn blocksplit_attempt<W: Write>(
         let store = lz77_optimal(
             &mut s,
             in_data,
-            last,
-            item,
             options.iteration_count.map(NonZeroU64::get),
             options.iterations_without_improvement.map(NonZeroU64::get),
         );
@@ -1212,8 +1210,6 @@ fn blocksplit_attempt<W: Write>(
     let store = lz77_optimal(
         &mut s,
         in_data,
-        last,
-        inend,
         options.iteration_count.map(NonZeroU64::get),
         options.iterations_without_improvement.map(NonZeroU64::get),
     );

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -204,9 +204,9 @@ fn deflate_part<W: Write>(
         }
         BlockType::Fixed => {
             let mut store = Lz77Store::new();
-            let mut s = ZopfliBlockState::new(options, instart, inend);
+            let mut s = ZopfliBlockState::new(options, in_data, instart, inend);
 
-            lz77_optimal_fixed(&mut s, in_data, instart, inend, &mut store);
+            lz77_optimal_fixed(&mut s, &mut store);
             add_lz77_block(
                 btype,
                 final_block,
@@ -1064,8 +1064,8 @@ fn add_lz77_block_auto_type<W: Write>(
         let instart = lz77.pos[lstart];
         let inend = instart + lz77.get_byte_range(lstart, lend);
 
-        let mut s = ZopfliBlockState::new(options, instart, inend);
-        lz77_optimal_fixed(&mut s, in_data, instart, inend, &mut fixedstore);
+        let mut s = ZopfliBlockState::new(options, in_data, instart, inend);
+        lz77_optimal_fixed(&mut s, &mut fixedstore);
         fixedcost = calculate_block_size(&fixedstore, 0, fixedstore.size(), BlockType::Fixed);
     }
 
@@ -1184,7 +1184,7 @@ fn blocksplit_attempt<W: Write>(
 
     let mut last = instart;
     for &item in &splitpoints_uncompressed {
-        let mut s = ZopfliBlockState::new(options, last, item);
+        let mut s = ZopfliBlockState::new(options, in_data, last, item);
 
         let store = lz77_optimal(
             &mut s,
@@ -1205,7 +1205,7 @@ fn blocksplit_attempt<W: Write>(
         last = item;
     }
 
-    let mut s = ZopfliBlockState::new(options, last, inend);
+    let mut s = ZopfliBlockState::new(options, in_data, last, inend);
 
     let store = lz77_optimal(
         &mut s,

--- a/src/lz77.rs
+++ b/src/lz77.rs
@@ -370,6 +370,7 @@ impl Lz77Store {
 /// but is kept for easy future expansion.
 pub struct ZopfliBlockState<'a, C> {
     pub options: &'a Options,
+    pub data: &'a [u8],
     /* Cache for length/distance pairs found so far. */
     lmc: C,
     /* The start (inclusive) and end (not inclusive) of the current block. */
@@ -378,9 +379,10 @@ pub struct ZopfliBlockState<'a, C> {
 }
 
 impl<'a> ZopfliBlockState<'a, ZopfliLongestMatchCache> {
-    pub fn new(options: &'a Options, blockstart: usize, blockend: usize) -> Self {
+    pub fn new(options: &'a Options, data: &'a [u8], blockstart: usize, blockend: usize) -> Self {
         ZopfliBlockState {
             options,
+            data,
             blockstart,
             blockend,
             lmc: ZopfliLongestMatchCache::new(blockend - blockstart),
@@ -389,9 +391,15 @@ impl<'a> ZopfliBlockState<'a, ZopfliLongestMatchCache> {
 }
 
 impl<'a> ZopfliBlockState<'a, NoCache> {
-    pub fn new_without_cache(options: &'a Options, blockstart: usize, blockend: usize) -> Self {
+    pub fn new_without_cache(
+        options: &'a Options,
+        data: &'a [u8],
+        blockstart: usize,
+        blockend: usize,
+    ) -> Self {
         ZopfliBlockState {
             options,
+            data,
             blockstart,
             blockend,
             lmc: NoCache,

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -392,13 +392,13 @@ fn trace(size: usize, length_array: &[u16]) -> Vec<u16> {
 fn lz77_optimal_run<F: Fn(usize, u16) -> f64, C: Cache>(
     s: &mut ZopfliBlockState<C>,
     in_data: &[u8],
-    instart: usize,
-    inend: usize,
     costmodel: F,
     store: &mut Lz77Store,
     h: &mut ZopfliHash,
     costs: &mut Vec<f32>,
 ) {
+    let instart = s.blockstart;
+    let inend = s.blockend;
     let (cost, length_array) = get_best_lengths(s, in_data, instart, inend, costmodel, h, costs);
     let path = trace(inend - instart, &length_array);
     store.follow_path(in_data, instart, inend, path, s);
@@ -427,8 +427,6 @@ pub fn lz77_optimal_fixed<C: Cache>(
     lz77_optimal_run(
         s,
         in_data,
-        instart,
-        inend,
         get_cost_fixed,
         store,
         &mut h,
@@ -442,11 +440,11 @@ pub fn lz77_optimal_fixed<C: Cache>(
 pub fn lz77_optimal<C: Cache>(
     s: &mut ZopfliBlockState<C>,
     in_data: &[u8],
-    instart: usize,
-    inend: usize,
     max_iterations: Option<u64>,
     max_iterations_without_improvement: Option<u64>,
 ) -> Lz77Store {
+    let instart = s.blockstart;
+    let inend = s.blockend;
     /* Dist to get to here with smallest cost. */
     let mut currentstore = Lz77Store::new();
     let mut outputstore = currentstore.clone();
@@ -478,8 +476,6 @@ pub fn lz77_optimal<C: Cache>(
         lz77_optimal_run(
             s,
             in_data,
-            instart,
-            inend,
             |a, b| get_cost_stat(a, b, &stats),
             &mut currentstore,
             &mut h,

--- a/src/squeeze.rs
+++ b/src/squeeze.rs
@@ -240,22 +240,20 @@ fn get_cost_model_min_cost<F: Fn(usize, u16) -> f64>(costmodel: F) -> f64 {
 /// Performs the forward pass for "squeeze". Gets the most optimal length to reach
 /// every byte from a previous byte, using cost calculations.
 /// `s`: the `ZopfliBlockState`
-/// `in_data`: the input data array
-/// `instart`: where to start
-/// `inend`: where to stop (not inclusive)
 /// `costmodel`: function to calculate the cost of some lit/len/dist pair.
 /// `length_array`: output array of size `(inend - instart)` which will receive the best
 ///     length to reach this byte from a previous byte.
 /// returns the cost that was, according to the `costmodel`, needed to get to the end.
 fn get_best_lengths<F: Fn(usize, u16) -> f64, C: Cache>(
     s: &mut ZopfliBlockState<C>,
-    in_data: &[u8],
-    instart: usize,
-    inend: usize,
     costmodel: F,
     h: &mut ZopfliHash,
     costs: &mut Vec<f32>,
 ) -> (f64, Vec<u16>) {
+    let in_data = s.data;
+    let instart = s.blockstart;
+    let inend = s.blockend;
+
     // Best cost to get here so far.
     let blocksize = inend - instart;
     let mut length_array = vec![0; blocksize + 1];
@@ -399,7 +397,7 @@ fn lz77_optimal_run<F: Fn(usize, u16) -> f64, C: Cache>(
     let instart = s.blockstart;
     let inend = s.blockend;
     let in_data = s.data;
-    let (cost, length_array) = get_best_lengths(s, in_data, instart, inend, costmodel, h, costs);
+    let (cost, length_array) = get_best_lengths(s, costmodel, h, costs);
     let path = trace(inend - instart, &length_array);
     store.follow_path(in_data, instart, inend, path, s);
     debug_assert!(cost < f64::INFINITY);


### PR DESCRIPTION
This PR takes instart and inend from the corresponding fields of the borrowed ZopfliBlockState, and moves in_data into that struct. Thus, several methods now have fewer parameters and a few redundant copies are eliminated.