### PR TITLE
Eliminate ZopfliBlockState and instead pass members that are used

### DIFF
--- a/src/blocksplitter.rs
+++ b/src/blocksplitter.rs
@@ -2,11 +2,7 @@ use alloc::vec::Vec;
 
 use log::{debug, log_enabled};
 
-use crate::{
-    deflate::calculate_block_size_auto_type,
-    lz77::{Lz77Store, ZopfliBlockState},
-    Options,
-};
+use crate::{cache::NoCache, deflate::calculate_block_size_auto_type, lz77::Lz77Store};
 
 /// Finds minimum of function `f(i)` where `i` is of type `usize`, `f(i)` is of type
 /// `f64`, `i` is in range `start-end` (excluding `end`).
@@ -218,7 +214,6 @@ pub fn blocksplit_lz77(lz77: &Lz77Store, maxblocks: u16, splitpoints: &mut Vec<u
 /// npoints: pointer to amount of splitpoints, for the dynamic array. The amount of
 ///   blocks is the amount of splitpoitns + 1.
 pub fn blocksplit(
-    options: &Options,
     in_data: &[u8],
     instart: usize,
     inend: usize,
@@ -231,8 +226,7 @@ pub fn blocksplit(
     /* Unintuitively, Using a simple LZ77 method here instead of lz77_optimal
     results in better blocks. */
     {
-        let mut state = ZopfliBlockState::new_without_cache(options, instart, inend);
-        store.greedy(&mut state, in_data, instart, inend);
+        store.greedy(&mut NoCache, in_data, instart, inend);
     }
 
     let mut lz77splitpoints = Vec::with_capacity(maxblocks as usize);

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -5,9 +5,10 @@ use log::{debug, log_enabled};
 
 use crate::{
     blocksplitter::{blocksplit, blocksplit_lz77},
+    cache::ZopfliLongestMatchCache,
     iter::ToFlagLastIterator,
     katajainen::length_limited_code_lengths,
-    lz77::{LitLen, Lz77Store, ZopfliBlockState},
+    lz77::{LitLen, Lz77Store},
     squeeze::{lz77_optimal, lz77_optimal_fixed},
     symbols::{
         get_dist_extra_bits, get_dist_extra_bits_value, get_dist_symbol,
@@ -204,9 +205,14 @@ fn deflate_part<W: Write>(
         }
         BlockType::Fixed => {
             let mut store = Lz77Store::new();
-            let mut s = ZopfliBlockState::new(options, instart, inend);
 
-            lz77_optimal_fixed(&mut s, in_data, instart, inend, &mut store);
+            lz77_optimal_fixed(
+                &mut ZopfliLongestMatchCache::new(inend - instart),
+                in_data,
+                instart,
+                inend,
+                &mut store,
+            );
             add_lz77_block(
                 btype,
                 final_block,
@@ -1033,7 +1039,6 @@ fn add_lz77_data<W: Write>(
 
 #[allow(clippy::too_many_arguments)] // Not feasible to refactor in a more readable way
 fn add_lz77_block_auto_type<W: Write>(
-    options: &Options,
     final_block: bool,
     in_data: &[u8],
     lz77: &Lz77Store,
@@ -1064,8 +1069,13 @@ fn add_lz77_block_auto_type<W: Write>(
         let instart = lz77.pos[lstart];
         let inend = instart + lz77.get_byte_range(lstart, lend);
 
-        let mut s = ZopfliBlockState::new(options, instart, inend);
-        lz77_optimal_fixed(&mut s, in_data, instart, inend, &mut fixedstore);
+        lz77_optimal_fixed(
+            &mut ZopfliLongestMatchCache::new(inend - instart),
+            in_data,
+            instart,
+            inend,
+            &mut fixedstore,
+        );
         fixedcost = calculate_block_size(&fixedstore, 0, fixedstore.size(), BlockType::Fixed);
     }
 
@@ -1135,18 +1145,16 @@ pub fn calculate_block_size_auto_type(lz77: &Lz77Store, lstart: usize, lend: usi
 fn add_all_blocks<W: Write>(
     splitpoints: &[usize],
     lz77: &Lz77Store,
-    options: &Options,
     final_block: bool,
     in_data: &[u8],
     bitwise_writer: &mut BitwiseWriter<W>,
 ) -> Result<(), Error> {
     let mut last = 0;
     for &item in splitpoints.iter() {
-        add_lz77_block_auto_type(options, false, in_data, lz77, last, item, 0, bitwise_writer)?;
+        add_lz77_block_auto_type(false, in_data, lz77, last, item, 0, bitwise_writer)?;
         last = item;
     }
     add_lz77_block_auto_type(
-        options,
         final_block,
         in_data,
         lz77,
@@ -1172,7 +1180,6 @@ fn blocksplit_attempt<W: Write>(
     let mut splitpoints_uncompressed = Vec::with_capacity(options.maximum_block_splits as usize);
 
     blocksplit(
-        options,
         in_data,
         instart,
         inend,
@@ -1184,10 +1191,8 @@ fn blocksplit_attempt<W: Write>(
 
     let mut last = instart;
     for &item in &splitpoints_uncompressed {
-        let mut s = ZopfliBlockState::new(options, last, item);
-
         let store = lz77_optimal(
-            &mut s,
+            &mut ZopfliLongestMatchCache::new(item - last),
             in_data,
             last,
             item,
@@ -1207,10 +1212,8 @@ fn blocksplit_attempt<W: Write>(
         last = item;
     }
 
-    let mut s = ZopfliBlockState::new(options, last, inend);
-
     let store = lz77_optimal(
-        &mut s,
+        &mut ZopfliLongestMatchCache::new(inend - last),
         in_data,
         last,
         inend,
@@ -1244,14 +1247,7 @@ fn blocksplit_attempt<W: Write>(
         }
     }
 
-    add_all_blocks(
-        &splitpoints,
-        &lz77,
-        options,
-        final_block,
-        in_data,
-        bitwise_writer,
-    )
+    add_all_blocks(&splitpoints, &lz77, final_block, in_data, bitwise_writer)
 }
 
 /// Since an uncompressed block can be max 65535 in size, it actually adds


### PR DESCRIPTION
Inspired by the performance regression in #24, this PR attempts to improve performance by doing the opposite.

Most methods taking a ZopfliBlockState use only the cache, so this PR changes them to take the cache itself as a parameter and eliminates the ZopfliBlockState struct. This saves a pointer indirection and some passing and copying of unused `&Options`.

Quick performance test with `time ./test/run.sh` on my 2019 MacBook Pro (Core i7-8569U 2.8GHz, macOS Ventura 13.4, 16GiB):

With commit 95f49a0:

    test/run.sh  18.70s user 0.61s system 94% cpu 20.463 total
    test/run.sh  15.22s user 0.47s system 98% cpu 15.962 total
    test/run.sh  13.59s user 0.42s system 98% cpu 14.280 total
    test/run.sh  13.26s user 0.43s system 98% cpu 13.929 total

With this PR:

    test/run.sh  12.93s user 0.39s system 94% cpu 14.070 total
    test/run.sh  13.90s user 0.38s system 86% cpu 16.435 total
    test/run.sh  12.53s user 0.37s system 98% cpu 13.130 total
    test/run.sh  12.49s user 0.36s system 98% cpu 13.082 total