### PR TITLE
feat: introduces build benchmarks; to establish a baseline for improvements

### DIFF
--- a/benchmark-builds/.gitignore
+++ b/benchmark-builds/.gitignore
@@ -1,0 +1,5 @@
+data/*.gz
+data_google
+data_rust
+zopfli
+benchmark*.json

--- a/benchmark-builds/README.md
+++ b/benchmark-builds/README.md
@@ -1,0 +1,13 @@
+## What kind of benchmarks?
+
+The purpose of this, is to bench the current rust version vs. the [original version](https://github.com/google/zopfli/blob/master/README).
+
+The measurement is done using [hyperfine](https://github.com/sharkdp/hyperfine).
+
+## How to
+
+To bench, run: (requires `git` and [zopfli requirements](https://github.com/google/zopfli/blob/master/README))
+
+```
+$ cd benchmark-builds && ./bench.sh
+```

--- a/benchmark-builds/bench.sh
+++ b/benchmark-builds/bench.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+#Get Google's version and build rust version
+./prepare.sh
+
+# Clean output from previous runs
+rm -f  benchmark-builds*.json
+rm -f  data/*.gz
+rm -rf data_google data_rust
+
+# Duplicate the input data for the bench execution,
+# to avoid any side effect due to either having to
+# 'delete the output' or 'overwrite the output' during the bench.
+cp -r data data_google
+cp -r data data_rust
+
+# Bench all input cases individually,
+# and store respective results.
+for input in $(ls data | grep -v '\.gz$'); do
+	printf "Benching with ${input}...\n"
+	command_name="Google zopfli with '${input}'"
+	command="zopfli/zopfli data_google/${input}" 
+	command_name1="Rust zopfli with '${input}'"
+	command1="../target/release/zopfli data_rust/${input}"
+	hyperfine \
+		--ignore-failure \
+		-N \
+		--export-json="benchmark-builds_${input}.json" \
+		--warmup=3 \
+		--time-unit=millisecond \
+		--command-name="${command_name}" "${command}" \
+		--command-name="${command_name1}" "${command1}"
+done

--- a/benchmark-builds/data
+++ b/benchmark-builds/data
@@ -1,0 +1,1 @@
+../test/data

--- a/benchmark-builds/prepare.sh
+++ b/benchmark-builds/prepare.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+# Clone Google/zopfli repo
+if [ ! -d "./zopfli" ]
+then
+    git clone https://github.com/google/zopfli
+fi
+
+# Build Google/zopfli
+cd zopfli && make && cd -
+
+# Build zopfli-rs
+cd .. && cargo build --release && cd -


### PR DESCRIPTION
Introduces 'Rust implementation' vs. 'Google implementation' benchmarks to establish a baseline for improvements. (bench using [Gzip ](https://github.com/zopfli-rs/zopfli/blob/1d187607f4e0e40e8c83c3109cba9da468f26854/src/main.rs#L11) for now)
The current result (using my hardware) shows that the Rust version is slightly slower than the Google's one.
```
Benching with 30-min.csv...
Benchmark 1: Google zopfli with '30-min.csv'
  Time (mean ± σ):      24.3 ms ±   1.9 ms    [User: 23.3 ms, System: 0.8 ms]
  Range (min … max):    20.7 ms …  30.1 ms    139 runs

Benchmark 2: Rust zopfli with '30-min.csv'
  Time (mean ± σ):      26.0 ms ±   3.0 ms    [User: 24.7 ms, System: 1.1 ms]
  Range (min … max):    22.5 ms …  35.1 ms    124 runs

Summary
  'Google zopfli with '30-min.csv'' ran
    1.07 ± 0.15 times faster than 'Rust zopfli with '30-min.csv''

Benching with calgary-books.txt...
Benchmark 1: Google zopfli with 'calgary-books.txt'
  Time (mean ± σ):     3456.7 ms ± 142.4 ms    [User: 3419.4 ms, System: 36.0 ms]
  Range (min … max):   3235.5 ms … 3712.6 ms    10 runs

Benchmark 2: Rust zopfli with 'calgary-books.txt'
  Time (mean ± σ):     4546.1 ms ± 120.9 ms    [User: 3949.3 ms, System: 589.0 ms]
  Range (min … max):   4398.8 ms … 4821.8 ms    10 runs

Summary
  'Google zopfli with 'calgary-books.txt'' ran
    1.32 ± 0.06 times faster than 'Rust zopfli with 'calgary-books.txt''

Benching with codetriage.js...
Benchmark 1: Google zopfli with 'codetriage.js'
  Time (mean ± σ):     360.6 ms ±  32.0 ms    [User: 355.5 ms, System: 5.0 ms]
  Range (min … max):   318.2 ms … 404.6 ms    10 runs

Benchmark 2: Rust zopfli with 'codetriage.js'
  Time (mean ± σ):     435.0 ms ±  30.3 ms    [User: 380.9 ms, System: 45.9 ms]
  Range (min … max):   384.4 ms … 499.1 ms    10 runs

Summary
  'Google zopfli with 'codetriage.js'' ran
    1.21 ± 0.14 times faster than 'Rust zopfli with 'codetriage.js''

Benching with computer.png...
Benchmark 1: Google zopfli with 'computer.png'
  Time (mean ± σ):      38.3 ms ±   4.7 ms    [User: 34.7 ms, System: 3.4 ms]
  Range (min … max):    32.7 ms …  54.7 ms    84 runs

Benchmark 2: Rust zopfli with 'computer.png'
  Time (mean ± σ):      52.2 ms ±   8.2 ms    [User: 35.5 ms, System: 16.5 ms]
  Range (min … max):    42.6 ms …  79.4 ms    48 runs

Summary
  'Google zopfli with 'computer.png'' ran
    1.36 ± 0.27 times faster than 'Rust zopfli with 'computer.png''

Benching with eeyore.png...
Benchmark 1: Google zopfli with 'eeyore.png'
  Time (mean ± σ):     256.3 ms ±  32.7 ms    [User: 242.1 ms, System: 13.9 ms]
  Range (min … max):   211.8 ms … 306.5 ms    10 runs

Benchmark 2: Rust zopfli with 'eeyore.png'
  Time (mean ± σ):     364.5 ms ±  36.6 ms    [User: 223.0 ms, System: 134.0 ms]
  Range (min … max):   327.6 ms … 427.6 ms    10 runs

Summary
  'Google zopfli with 'eeyore.png'' ran
    1.42 ± 0.23 times faster than 'Rust zopfli with 'eeyore.png''

Benching with empty.txt...
Benchmark 1: Google zopfli with 'empty.txt'
  Time (mean ± σ):       0.7 ms ±   0.1 ms    [User: 0.6 ms, System: 0.0 ms]
  Range (min … max):     0.5 ms …   2.5 ms    1730 runs

Benchmark 2: Rust zopfli with 'empty.txt'
  Time (mean ± σ):       1.1 ms ±   0.1 ms    [User: 1.0 ms, System: 0.1 ms]
  Range (min … max):     0.8 ms …   2.2 ms    3081 runs

Summary
  'Google zopfli with 'empty.txt'' ran
    1.53 ± 0.24 times faster than 'Rust zopfli with 'empty.txt''

Benching with heartbleed.png...
Benchmark 1: Google zopfli with 'heartbleed.png'
  Time (mean ± σ):      34.9 ms ±   4.1 ms    [User: 32.2 ms, System: 2.6 ms]
  Range (min … max):    30.0 ms …  44.2 ms    90 runs

Benchmark 2: Rust zopfli with 'heartbleed.png'
  Time (mean ± σ):      51.3 ms ±   7.3 ms    [User: 30.6 ms, System: 20.6 ms]
  Range (min … max):    41.3 ms …  63.1 ms    66 runs

Summary
  'Google zopfli with 'heartbleed.png'' ran
    1.47 ± 0.27 times faster than 'Rust zopfli with 'heartbleed.png''

Benching with master-block-size-zeros.bin...
Benchmark 1: Google zopfli with 'master-block-size-zeros.bin'
  Time (mean ± σ):     302.3 ms ±  20.5 ms    [User: 297.2 ms, System: 5.0 ms]
  Range (min … max):   274.8 ms … 343.9 ms    10 runs

Benchmark 2: Rust zopfli with 'master-block-size-zeros.bin'
  Time (mean ± σ):     8450.1 ms ± 520.9 ms    [User: 8415.9 ms, System: 34.0 ms]
  Range (min … max):   7622.2 ms … 9080.3 ms    10 runs

Summary
  'Google zopfli with 'master-block-size-zeros.bin'' ran
   27.96 ± 2.56 times faster than 'Rust zopfli with 'master-block-size-zeros.bin''
```

