### PR TITLE
Exclude more files from the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,14 @@ homepage = "https://github.com/zopfli-rs/zopfli"
 repository = "https://github.com/zopfli-rs/zopfli"
 readme = "README.md"
 categories = ["compression", "no-std"]
-exclude = ["test/*"]
+exclude = [
+    ".github/*",
+    ".gitignore",
+    "Makefile",
+    "benchmark-builds/*",
+    "rustfmt.toml",
+    "test/*",
+]
 edition = "2021"
 rust-version = "1.66"
 


### PR DESCRIPTION
The tests were already excluded from the published crate. This change adds `Makefile`, `rustfmt.toml`, and the contents of `benchmark-builds/`, all of which are not used by cargo to build the published crate.

This was suggested in [downstream packaging review](https://bugzilla.redhat.com/show_bug.cgi?id=2259758#c2).