### PR TITLE
Add DeflateEncoder::get_ref/get_mut

### DIFF
--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -134,6 +134,19 @@ impl<W: Write> DeflateEncoder<W> {
 
         Ok(Some(bitwise_writer.out))
     }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        &self.bitwise_writer.as_ref().unwrap().out
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// Note that mutating the output/input state of the stream may corrupt
+    /// this object, so care must be taken when using this method.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.bitwise_writer.as_mut().unwrap().out
+    }
 }
 
 impl<W: Write> Write for DeflateEncoder<W> {

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -76,6 +76,19 @@ impl<W: Write> GzipEncoder<W> {
 
         Ok(Some(sink))
     }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        self.deflate_encoder.as_ref().unwrap().get_ref()
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// Note that mutating the output/input state of the stream may corrupt
+    /// this object, so care must be taken when using this method.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.deflate_encoder.as_mut().unwrap().get_mut()
+    }
 }
 
 impl<W: Write> Write for GzipEncoder<W> {

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -70,6 +70,19 @@ impl<W: Write> ZlibEncoder<W> {
 
         Ok(Some(sink))
     }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        self.deflate_encoder.as_ref().unwrap().get_ref()
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// Note that mutating the output/input state of the stream may corrupt
+    /// this object, so care must be taken when using this method.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.deflate_encoder.as_mut().unwrap().get_mut()
+    }
 }
 
 impl<W: Write> Write for ZlibEncoder<W> {


### PR DESCRIPTION
These allow accessing the underlying writer, which can be useful to read out the underlying state, for instance to send it out.

In my case, I need to deflate to a Vec<u8>, that will be periodically (after some writes) sent out and replaced. We have to work this way due to API constraints.

Most of the compression crates out there already offer support for getting the underlying writer ([bzip2](https://docs.rs/bzip2/latest/bzip2/write/struct.BzEncoder.html#method.get_ref), [zstd](https://docs.rs/zstd/latest/zstd/stream/write/struct.Encoder.html#method.get_ref), [flate2](https://docs.rs/flate2/latest/flate2/write/struct.DeflateEncoder.html#method.get_ref)).